### PR TITLE
Testing/homerow mods

### DIFF
--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -35,10 +35,10 @@
         compatible = "zmk,keymap";
         default_layer {
             bindings = <
-            &kp Q           &kp W       &kp E       &kp R             &kp T         &kp Y          &kp U                 &kp I         &kp O         &kp P
-            &hm_l LCTRL A   &hm_l LALT  &hm_l LGUI  &hm_shift_l LSFT  &kp G         &kp H          &hm_shift_r RSHFT J   &hm_r RGUI K  &hm_r RALT L  &hm_r LCTRL SQT 
-            &ht RALT Z      &kp X       &kp C       &kp V             &kp B         &kp N          &kp M                 &kp COMMA     &kp DOT       &ht RALT FSLH
-                                                    &lt NAV TAB       &lt SYM ESC   &lt NUM ENTER  &lt NAV SPACE
+            &kp Q           &kp W         &kp E         &kp R               &kp T         &kp Y          &kp U                &kp I         &kp O         &kp P
+            &hm_l LCTRL A   &hm_l LALT S  &hm_l LGUI D  &hm_shift_l LSFT F  &kp G         &kp H          &hm_shift_r LSFT J   &hm_r RGUI K  &hm_r RALT L  &hm_r LCTRL SQT
+            &ht RALT Z      &kp X         &kp C         &kp V               &kp B         &kp N          &kp M                &kp COMMA     &kp DOT       &ht RALT FSLH
+                                                        &lt NAV TAB         &lt SYM ESC   &lt NUM ENTER  &lt NAV SPACE
             >;
         };
 

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -7,10 +7,6 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
-// Home row mods macro
-#define HRML(k1,k2,k3,k4) &ht LCTRL k1  &ht LALT k2  &ht LGUI k3  &ht LSFT k4
-#define HRMR(k1,k2,k3,k4) &ht LSFT k1   &ht LGUI k2  &ht LALT k3  &ht LCTRL k4
-
 // Layer definitions
 #define BASE 0
 #define SYM 1
@@ -20,6 +16,7 @@
 
 // Personal includes
 #include "includes/conditional_layers.dtsi"
+#include "includes/behaviors_homerow_mods.dtsi"
 #include "includes/behaviors_other.dtsi"
 #include "includes/combos.dtsi"
 
@@ -38,10 +35,10 @@
         compatible = "zmk,keymap";
         default_layer {
             bindings = <
-            &kp Q      &kp W      &kp E      &kp R         &kp T              &kp Y          &kp U      &kp I      &kp O      &kp P
-            HRML(A,        S,         D,         F)        &kp G              &kp H          HRMR(J,        K,         L,        SQT)
-            &ht RALT Z &kp X      &kp C      &kp V         &kp B              &kp N          &kp M      &kp COMMA  &kp DOT    &ht RALT FSLH
-                                             &lt NAV TAB   &lt SYM ESC        &lt NUM ENTER  &lt NAV SPACE
+            &kp Q           &kp W       &kp E       &kp R             &kp T         &kp Y          &kp U                 &kp I         &kp O         &kp P
+            &hm_l LCTRL A   &hm_l LALT  &hm_l LGUI  &hm_shift_l LSFT  &kp G         &kp H          &hm_shift_r RSHFT J   &hm_r RGUI K  &hm_r RALT L  &hm_r LCTRL SQT 
+            &ht RALT Z      &kp X       &kp C       &kp V             &kp B         &kp N          &kp M                 &kp COMMA     &kp DOT       &ht RALT FSLH
+                                                    &lt NAV TAB       &lt SYM ESC   &lt NUM ENTER  &lt NAV SPACE
             >;
         };
 

--- a/config/includes/behaviors_homerow_mods.dtsi
+++ b/config/includes/behaviors_homerow_mods.dtsi
@@ -1,0 +1,76 @@
+#define HM_TAPPING_TERM 300
+#define HM_TAPPING_TERM_FAST 200
+#define HM_PRIOR_IDLE 150
+
+/ {
+    behaviors {
+
+        // Positional Homerow mods
+        // Homerow mods that prevent accidental activations when rolling keys,
+        // such as when typing `st` or `ne` on colemak-dh layouts or `as` on
+        // qwerty.
+        //
+        // Works by only allowing a mod to activate within tapping-term if
+        // it's on the opposite side of the keyboard or on the same side thumb
+        // keys.
+
+        hm_l: homerow_mods_left {
+          compatible = "zmk,behavior-hold-tap";
+          #binding-cells = <2>;
+          bindings = <&kp>, <&kp>;
+
+          flavor = "balanced";
+          tapping-term-ms = <HM_TAPPING_TERM>;
+          quick-tap-ms = <175>;
+          require-prior-idle-ms = <HM_PRIOR_IDLE>;
+
+          // hold-trigger-key-positions = <KEYS_R KEYS_T>;
+          hold-trigger-on-release;
+        };
+
+        hm_r: homerow_mods_right {
+          compatible = "zmk,behavior-hold-tap";
+          #binding-cells = <2>;
+          bindings = <&kp>, <&kp>;
+
+          flavor = "balanced";
+          tapping-term-ms = <HM_TAPPING_TERM>;
+          quick-tap-ms = <175>;
+          require-prior-idle-ms = <HM_PRIOR_IDLE>;
+
+          // hold-trigger-key-positions = <KEYS_L KEYS_T>;
+          hold-trigger-on-release;
+        };
+
+        // Positional Homerow mods for shift
+        // Use faster tapping term and disable some features that may
+        // cause false negatives.
+        hm_shift_l: hm_shift_l {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            bindings = <&kp>, <&kp>;
+
+            flavor = "balanced";
+            tapping-term-ms = <HM_TAPPING_TERM_FAST>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <HM_PRIOR_IDLE>;
+
+            // hold-trigger-key-positions = <KEYS_R KEYS_T>;
+            // hold-trigger-on-release;
+        };
+
+        hm_shift_r: hm_shift_r {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            bindings = <&kp>, <&kp>;
+
+            flavor = "balanced";
+            tapping-term-ms = <HM_TAPPING_TERM_FAST>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <HM_PRIOR_IDLE>;
+
+            // hold-trigger-key-positions = <KEYS_L KEYS_T>;
+            // hold-trigger-on-release;
+        };
+    };
+};


### PR DESCRIPTION
- defines homerow mods specific for left and right half of the keyboard
- improves tapping terms etc.